### PR TITLE
React.memoの使用方法

### DIFF
--- a/src/components/Cockpit/Cockpit.js
+++ b/src/components/Cockpit/Cockpit.js
@@ -27,16 +27,16 @@ const cockpit = props => {
     btnClass = classes.Red;
   }
 
-  if (props.persons.length <= 2) {
+  if (props.personsLength <= 2) {
     assignClasses.push(classes.red); // assignClasses =  ["red"]
   }
-  if (props.persons.length <= 1) {
+  if (props.personsLength <= 1) {
     assignClasses.push(classes.bold); // assignClasses =  ["red", "bold"]
   }
 
   return (
     <div className={classes.Cockpit}>
-      <h1>Hi, I'm React App!!!</h1>
+      <h1>{props.title}</h1>
       <p className={assignClasses.join(" ")}>This is really working!!</p>
       <button className={btnClass} onClick={props.clicked}>
         Toggle Persons
@@ -45,4 +45,4 @@ const cockpit = props => {
   );
 };
 
-export default cockpit;
+export default React.memo(cockpit);

--- a/src/components/Persons/Persons.js
+++ b/src/components/Persons/Persons.js
@@ -9,7 +9,11 @@ class Persons extends Component {
 
   shouldComponentUpdate(nextProps, nextState) {
     console.log("[Persons.js] shouldComponentUpdate");
-    return true;
+    if (nextProps.persons !== this.props.persons) {
+      return true;
+    } else {
+      return false;
+    }
   }
 
   getSnapshotBeforeUpdate() {

--- a/src/container/App.js
+++ b/src/container/App.js
@@ -94,8 +94,9 @@ class App extends Component {
         {this.state.showCockpit ? (
           <Cockpit
             showPersons={this.state.showPersons}
-            persons={this.state.persons}
+            personsLength={this.state.persons.length}
             clicked={this.togglePersonsHandler}
+            title={this.props.appTitle}
           />
         ) : null}
 

--- a/src/index.js
+++ b/src/index.js
@@ -4,5 +4,8 @@ import "./index.css";
 import App from "./container/App";
 import registerServiceWorker from "./registerServiceWorker";
 
-ReactDOM.render(<App />, document.getElementById("root"));
+ReactDOM.render(
+  <App appTitle="Person Manager" />,
+  document.getElementById("root")
+);
 registerServiceWorker();


### PR DESCRIPTION
### 以下の項目を入力してください。

#### 新規機能
- React.memoの実装

---

#### 既存機能

---

#### このブランチで学んだこと
- React.memo
一言でまとめると、最後のレンダー結果を再利用する。
関数コンポーネントに渡ってきたpropsが変化したときは再レンダリングかつメモ化する、変化なしの場合は以前のメモ化していたものを再利用する。
こうすることで無駄なレンダリングを防ぎ、パフォーマンスを向上させることが可能になる。

---

#### TODO

---

#### レビュワーへの報告

---

#### 影響範囲

---

#### スクリーンショット(before/after)

---

#### 参考にしたソース

---

#### チケット
