### PR TITLE
PersonsコンポーネントをPureComponent化

### DIFF
--- a/src/components/Persons/Persons.js
+++ b/src/components/Persons/Persons.js
@@ -1,20 +1,24 @@
-import React, { Component } from "react";
+import React, { PureComponent } from "react";
 import Person from "./Person/Person";
 
-class Persons extends Component {
+class Persons extends PureComponent {
   // static getDerivedStateFromProps(props, state) {
   //   console.log("Persons.js] getDerivedStateFromProps");
   //   return state;
   // }
 
-  shouldComponentUpdate(nextProps, nextState) {
-    console.log("[Persons.js] shouldComponentUpdate");
-    if (nextProps.persons !== this.props.persons) {
-      return true;
-    } else {
-      return false;
-    }
-  }
+  // shouldComponentUpdate(nextProps, nextState) {
+  //   console.log("[Persons.js] shouldComponentUpdate");
+  //   if (
+  //     nextProps.persons !== this.props.persons ||
+  //     nextProps.changed !== this.props.changed ||
+  //     nextProps.clicked !== this.props.clicked
+  //   ) {
+  //     return true;
+  //   } else {
+  //     return false;
+  //   }
+  // }
 
   getSnapshotBeforeUpdate() {
     console.log("[Persons.js] getSnapshotBeforeUpdate");


### PR DESCRIPTION
### 以下の項目を入力してください。

#### 新規機能
- PersonsコンポーネントをPureComponent化

---

#### 既存機能

---

#### このブランチで学んだこと
- PureComponent
React.PureComponent``は``shouldComponentUpdate()``を実行したcomponentです。(shallow-Equalしたかどうか)
違いを一言でまとめると、
``React.PureComponent``は``shouldComponentUpdate()``を実装、
``React.Component``は、実装していない。
shouldComponentUpdate()propsやstateに変化があったときに真偽値をreturnし、再レンダリングするかどうかを判定する。



---

#### TODO

---

#### レビュワーへの報告

---

#### 影響範囲

---

#### スクリーンショット(before/after)

---

#### 参考にしたソース

---

#### チケット
