### PR TITLE
state更新のベストプラクティス

### DIFF
--- a/src/container/App.js
+++ b/src/container/App.js
@@ -19,7 +19,8 @@ class App extends Component {
     ],
     otherState: "some other value",
     showPersons: false,
-    showCockpit: true
+    showCockpit: true,
+    changeCounter: 0
   };
 
   static getDerivedStateFromProps(props, state) {
@@ -55,7 +56,12 @@ class App extends Component {
     const persons = [...this.state.persons];
     persons[personIndex] = person;
 
-    this.setState({ persons: persons });
+    this.setState((prevState, props) => {
+      return {
+        persons: persons,
+        changeCounter: prevState.changeCounter + 1
+      };
+    });
   };
 
   deletePersonHandler = personIndex => {


### PR DESCRIPTION
### 以下の項目を入力してください。

#### 新規機能

---

#### 既存機能

---

#### このブランチで学んだこと
- setState関数の引数には第1引数にはprevState(レンダリング以前のstate)、第2引数にはpropsを渡せる。
- setStateをする時には、prevStateで更新するのがベストプラクティスらしい。


---

#### TODO

---

#### レビュワーへの報告

---

#### 影響範囲

---

#### スクリーンショット(before/after)

---

#### 参考にしたソース

---

#### チケット
